### PR TITLE
feat: Implement manual order sending to Navex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Toutes les modifications notables apportées à ce projet seront documentées dans ce fichier.
+
+Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.15] - 2025-07-19
+
+### Ajouté
+- **Tableau de Bord de Suivi :** Ajout d'une nouvelle page d'administration "Navex Delivery" pour afficher en temps réel le statut des colis via AJAX.
+- **Gestion Avancée des Tokens :** Création d'une page de réglages dédiée (`Navex Delivery > Settings`) avec des champs séparés pour les tokens d'API d'ajout, de récupération et de suppression.
+- **Icône de Menu Personnalisée :** Intégration d'une icône SVG personnalisée pour le menu principal du plugin.
+
+### Modifié
+- **Architecture Admin :** La classe `ABCD_WC_Navex_Admin` a été entièrement restructurée pour prendre en charge la nouvelle hiérarchie des menus et la Settings API de WordPress.
+- **Architecture API :** La classe `ABCD_WC_Navex_API` gère maintenant plusieurs tokens et a été préparée pour de futures méthodes (récupération, suppression).
+- **Sécurité AJAX :** Toutes les actions AJAX sont désormais sécurisées par un nonce WordPress unifié et vérifié, améliorant la protection contre les failles CSRF.
+- **Scripts Admin :** Le fichier `admin.js` a été mis à jour pour gérer la logique du nouveau tableau de bord de suivi.

--- a/README.md
+++ b/README.md
@@ -1,95 +1,54 @@
 # ABCDO Navex Integration for WooCommerce
 
-**Auteur:** ABCDO
-**Nom du plugin:** ABCDO Navex Integration for WooCommerce
-**Version:** 1.0.0
-**Dépôt GitHub:** `https://github.com/abcd-wc-navex/abcdo-wc-navex`
+**Auteur :** ABCDO
+**Version :** 1.0.15
+**Dépôt GitHub :** `https://github.com/ABCDO-TN/abcdo-wc-navex`
 
 ## Description
 
-Ce plugin intègre le service de livraison Navex directement dans WooCommerce. Il permet d'envoyer automatiquement les détails des commandes à l'API Navex pour créer des colis et de suivre leur statut depuis le tableau de bord WordPress.
+Ce plugin intègre le service de livraison Navex directement dans WooCommerce. Il permet d'envoyer les détails des commandes à l'API Navex pour créer des colis et de suivre leur statut depuis le tableau de bord WordPress.
 
-Le plugin inclut également un mécanisme de mise à jour automatique via GitHub pour simplifier la maintenance et le déploiement des nouvelles versions.
+Le plugin inclut un mécanisme de mise à jour automatique via GitHub pour simplifier la maintenance et le déploiement des nouvelles versions.
 
-## Feuille de Route (RDP)
+## Fonctionnalités
 
-### Phase 1 : Initialisation et Structure du Plugin
+*   **Tableau de Bord de Suivi :** Un tableau de bord centralisé pour visualiser en temps réel le statut de tous vos colis expédiés avec Navex.
+*   **Configuration Facile :** Une page de réglages dédiée pour configurer les clés d'API nécessaires à la communication avec Navex.
+*   **Envoi Manuel :** Un bouton sur chaque page de commande WooCommerce pour envoyer manuellement les informations du colis à Navex.
+*   **Mises à Jour Automatiques :** Recevez les notifications de nouvelles versions et mettez à jour le plugin en un clic depuis votre tableau de bord WordPress.
+*   **Compatibilité HPOS :** Entièrement compatible avec le système de stockage de commandes haute performance de WooCommerce.
 
--   [x] **Créer le fichier `README.md`** : Documentation initiale du projet.
--   [ ] **Créer la structure des fichiers** :
-    -   `abcdo-wc-navex.php` (Fichier principal du plugin)
-    -   `readme.txt` (Fichier standard pour le répertoire de plugins WordPress)
-    -   `LICENSE` (Licence du projet)
-    -   `.gitignore` (Pour exclure les fichiers non nécessaires)
-    -   `includes/` (Répertoire pour les classes et la logique métier)
-        -   `class-abcd-wc-navex-admin.php` (Gestion de l'interface d'administration)
-        -   `class-abcd-wc-navex-api.php` (Client pour l'API Navex)
-        -   `class-abcd-wc-navex-integration.php` (Logique d'intégration avec WooCommerce)
-        -   `class-abcd-wc-navex-updater.php` (Gestionnaire des mises à jour via GitHub)
-    -   `assets/` (Pour les fichiers CSS et JavaScript)
+## Installation
 
-### Phase 2 : Développement du Cœur du Plugin
+1.  Téléchargez la dernière version du plugin depuis la page [Releases](https://github.com/ABCDO-TN/abcdo-wc-navex/releases) du dépôt GitHub.
+2.  Dans votre tableau de bord WordPress, allez dans `Extensions > Ajouter`.
+3.  Cliquez sur `Téléverser une extension` et sélectionnez le fichier `.zip` que vous avez téléchargé.
+4.  Activez l'extension.
 
--   [ ] **Développer le fichier principal (`abcdo-wc-navex.php`)** :
-    -   Ajouter l'en-tête du plugin (nom, version, auteur, etc.).
-    -   Définir les constantes (`ABCDO_WC_NAVEX_VERSION`, `ABCDO_WC_NAVEX_PATH`).
-    -   Inclure les fichiers de classes du répertoire `includes/`.
-    -   Instancier les classes principales.
+## Configuration
 
--   [ ] **Créer la page de configuration (`class-abcd-wc-navex-admin.php`)** :
-    -   Ajouter un onglet "ABCDO Navex" dans `WooCommerce > Réglages > Intégration`.
-    -   Créer un champ pour que l'utilisateur puisse saisir et sauvegarder sa clé d'API Navex.
-    -   Sécuriser la sauvegarde et la récupération de la clé.
+Une fois le plugin activé, vous devez configurer vos clés d'API Navex pour permettre la communication avec leurs services.
 
--   [ ] **Implémenter le client API (`class-abcd-wc-navex-api.php`)** :
-    -   Créer une méthode `send_parcel()` qui prend les détails de la commande en paramètre.
-    -   Construire la requête POST vers `https://app.navex.tn/api/{TOKEN}/v1/post.php` en utilisant `wp_remote_post()`.
-    -   Gérer les réponses de l'API (succès, erreurs) et retourner un résultat structuré.
+1.  Dans le menu de gauche de WordPress, naviguez vers `Navex Delivery > Settings`.
+2.  Remplissez les champs suivants avec les informations fournies par Navex :
+    *   **Token d'ajout :** Nécessaire pour créer de nouveaux colis.
+    *   **Token de récupération :** Nécessaire pour suivre le statut des colis existants.
+    *   **Token de suppression :** Nécessaire pour annuler un colis.
+3.  Cliquez sur `Save Settings`.
 
--   [ ] **Intégrer avec WooCommerce (`class-abcd-wc-navex-integration.php`)** :
-    -   Utiliser le hook `woocommerce_order_status_changed` pour déclencher l'envoi à l'API Navex lorsque le statut d'une commande passe à "En cours de traitement" (ou un autre statut configurable).
-    -   Ajouter un "meta box" sur la page de détail de la commande pour afficher le statut de l'envoi Navex.
-    -   Ajouter un bouton dans ce "meta box" pour permettre un envoi manuel de la commande à Navex.
+## Utilisation
 
-### Phase 3 : Mises à Jour Automatiques
+### Suivi des Colis
 
--   [ ] **Développer le gestionnaire de mises à jour (`class-abcd-wc-navex-updater.php`)** :
-    -   Utiliser les filtres `pre_set_site_transient_update_plugins` et `plugins_api`.
-    -   Interroger l'API GitHub (`https://api.github.com/repos/{user}/{repo}/releases/latest`) pour vérifier l'existence d'une nouvelle version.
-    -   Si une nouvelle version est disponible, afficher une notification de mise à jour dans l'interface d'administration de WordPress.
-    -   Fournir l'URL du fichier `.zip` de la release pour permettre la mise à jour.
+Pour voir le statut de tous vos colis, allez dans `Navex Delivery` dans le menu principal de WordPress. Le tableau de bord se chargera et affichera la liste de vos envois.
 
-### Phase 4 : Automatisation du Déploiement (CI/CD)
+*Note : Cette fonctionnalité dépend du "Token de récupération". Assurez-vous qu'il est correctement configuré.*
 
--   [ ] **Créer le répertoire `.github/workflows/`**.
--   [ ] **Développer le workflow `release.yml`** :
-    -   Déclencher le workflow lors de la création d'une nouvelle "release" sur GitHub.
-    -   Utiliser une action pour archiver les fichiers du plugin dans un fichier `abcdo-wc-navex.zip`.
-    -   Exclure les fichiers et répertoires de développement (`.git`, `.github`, `README.md`, etc.) de l'archive `.zip` finale.
-    -   Attacher l'archive `.zip` en tant qu'artefact à la release GitHub.
+### Envoyer un Colis Manuellement
 
-## Spécifications de l'API Navex
+1.  Allez sur la page d'une commande WooCommerce (`WooCommerce > Commandes` et cliquez sur une commande).
+2.  Sur la droite, vous trouverez une boîte "ABCDO Navex Shipping".
+3.  Cliquez sur le bouton `Send to Navex` pour transmettre les informations de la commande à l'API Navex et créer le colis.
+4.  Le statut de l'envoi sera alors mis à jour dans la boîte.
 
--   **Endpoint :** `https://app.navex.tn/api/{TOKEN}/v1/post.php`
--   **Méthode :** `POST`
--   **Authentification :** La clé d'API est incluse dans l'URL.
--   **Corps de la requête :** `application/x-www-form-urlencoded`
-
-### Champs de la requête
-
-| Champ         | Description                      | Obligatoire | Type   |
-|---------------|----------------------------------|-------------|--------|
-| `prix`        | Prix total de la commande        | Oui         | string |
-| `nom`         | Nom complet du client            | Oui         | string |
-| `gouvernerat` | Gouvernorat de livraison         | Oui         | string |
-| `ville`       | Ville de livraison               | Oui         | string |
-| `adresse`     | Adresse de livraison             | Oui         | string |
-| `tel`         | Numéro de téléphone du client    | Oui         | string |
-| `tel2`        | Deuxième numéro de téléphone     | Non         | string |
-| `designation` | Description des articles         | Oui         | string |
-| `nb_article`  | Nombre total d'articles          | Oui         | number |
-| `msg`         | Message/note pour le livreur     | Non         | string |
-| `echange`     | Indique si c'est un échange      | Non         | string |
-| `article`     | Article à échanger               | Non         | string |
-| `nb_echange`  | Nombre d'articles à échanger     | Non         | string |
-| `ouvrir`      | Autorisation d'ouvrir le colis   | Oui         | string |
+*Note : Cette fonctionnalité dépend du "Token d'ajout".*

--- a/abcdo-wc-navex.php
+++ b/abcdo-wc-navex.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ABCDO Navex Integration for WooCommerce
  * Plugin URI:        https://github.com/ABCDO-TN/abcdo-wc-navex
  * Description:       Intègre l'API de livraison Navex avec WooCommerce pour automatiser la création de colis.
- * Version:           1.0.14
+ * Version:           1.0.15
  * Author:            ABCDO
  * Author URI:        https://abcdo.tn
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ add_action( 'before_woocommerce_init', function() {
 } );
 
 // Définir les constantes du plugin
-define( 'ABCDO_WC_NAVEX_VERSION', '1.0.14' );
+define( 'ABCDO_WC_NAVEX_VERSION', '1.0.15' );
 define( 'ABCDO_WC_NAVEX_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_URL', plugin_dir_url( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,41 +1,78 @@
-jQuery(document).ready(function($) {
-    $('#abcd-wc-navex-send-btn').on('click', function(e) {
-        e.preventDefault();
+(function($) {
+    'use strict';
 
-        var button = $(this);
-        var spinner = button.next('.spinner');
-        var orderId = button.data('order-id');
-        var nonce = $('#abcd_wc_navex_nonce').val();
+    $(function() {
 
-        // Afficher le spinner et désactiver le bouton
-        spinner.addClass('is-active');
-        button.prop('disabled', true);
+        // Logique pour le tableau de bord des colis
+        if ($('#navex-parcels-table').length) {
+            loadParcels();
+        }
 
-        $.ajax({
-            url: ajaxurl,
-            type: 'POST',
-            data: {
+        // Logique pour le bouton d'envoi sur la page de commande
+        $('#abcd-wc-navex-send-btn').on('click', function() {
+            var button = $(this);
+            var spinner = button.next('.spinner');
+            var orderId = button.data('order-id');
+            var nonce = $('#abcd_wc_navex_nonce').val();
+
+            button.prop('disabled', true);
+            spinner.css('visibility', 'visible');
+
+            var data = {
                 action: 'abcd_wc_navex_send_parcel',
                 order_id: orderId,
                 nonce: nonce
-            },
-            success: function(response) {
-                spinner.removeClass('is-active');
+            };
+
+            $.post(ajaxurl, data, function(response) {
+                button.prop('disabled', false);
+                spinner.css('visibility', 'hidden');
 
                 if (response.success) {
-                    // Remplacer le bouton par un message de succès
-                    button.siblings('p').html('<strong>Statut Navex :</strong> Envoyé');
-                    button.remove();
+                    alert(response.data.message);
+                    // Mettre à jour l'affichage du statut sans recharger la page
+                    button.closest('div').html('<p><strong>Navex Status:</strong> Envoyé</p>');
                 } else {
-                    alert('Erreur : ' + response.data.message);
-                    button.prop('disabled', false); // Réactiver le bouton seulement en cas d'erreur
+                    alert('Erreur: ' + response.data.message);
                 }
-            },
-            error: function(xhr, status, error) {
-                spinner.removeClass('is-active');
-                button.prop('disabled', false);
-                alert('Une erreur AJAX est survenue : ' + error);
-            }
+            });
         });
+
+        /**
+         * Charge les colis via AJAX et remplit le tableau.
+         */
+        function loadParcels() {
+            var tableBody = $('#navex-parcels-table tbody');
+            
+            var data = {
+                action: 'abcd_wc_navex_get_parcels',
+                nonce: abcd_wc_navex_ajax.nonce
+            };
+
+            $.post(abcd_wc_navex_ajax.ajax_url, data, function(response) {
+                tableBody.empty(); // Vider le message de chargement
+
+                if (response.success) {
+                    if (response.data.length > 0) {
+                        $.each(response.data, function(index, parcel) {
+                            var row = '<tr>' +
+                                '<td>' + parcel.order_id + '</td>' +
+                                '<td>' + parcel.tracking_id + '</td>' +
+                                '<td>' + parcel.status + '</td>' +
+                                '<td>' + parcel.date + '</td>' +
+                                '<td>' + parcel.actions + '</td>' +
+                                '</tr>';
+                            tableBody.append(row);
+                        });
+                    } else {
+                        tableBody.append('<tr><td colspan="5">Aucun colis trouvé.</td></tr>');
+                    }
+                } else {
+                    tableBody.append('<tr><td colspan="5">Erreur lors de la récupération des colis: ' + response.data.message + '</td></tr>');
+                }
+            });
+        }
+
     });
-});
+
+})(jQuery);

--- a/includes/class-abcd-wc-navex-api.php
+++ b/includes/class-abcd-wc-navex-api.php
@@ -22,17 +22,31 @@ class ABCD_WC_Navex_API {
     private static $api_url = 'https://app.navex.tn/api/';
 
     /**
-     * Le token d'API.
-     *
+     * Le token d'API pour l'ajout.
      * @var string
      */
-    private $api_token;
+    private $token_add;
+
+    /**
+     * Le token d'API pour la récupération.
+     * @var string
+     */
+    private $token_get;
+
+    /**
+     * Le token d'API pour la suppression.
+     * @var string
+     */
+    private $token_delete;
+
 
     /**
      * Constructeur.
      */
     public function __construct() {
-        $this->api_token = get_option( 'abcdo_wc_navex_api_token' );
+        $this->token_add    = get_option( 'abcdo_wc_navex_api_token_add' );
+        $this->token_get    = get_option( 'abcdo_wc_navex_api_token_get' );
+        $this->token_delete = get_option( 'abcdo_wc_navex_api_token_delete' );
     }
 
     /**
@@ -42,20 +56,55 @@ class ABCD_WC_Navex_API {
      * @return array|WP_Error La réponse de l'API ou une erreur.
      */
     public function send_parcel( $data ) {
-        if ( empty( $this->api_token ) ) {
-            return new WP_Error( 'api_token_missing', __( 'Le token d\'API Navex n\'est pas configuré.', 'abcdo-wc-navex' ) );
+        if ( empty( $this->token_add ) ) {
+            return new WP_Error( 'api_token_missing', __( 'Le token d\'ajout Navex n\'est pas configuré.', 'abcdo-wc-navex' ) );
         }
 
-        $endpoint = self::$api_url . $this->api_token . '/v1/post.php';
+        $endpoint = self::$api_url . $this->token_add . '/v1/post.php';
 
-        $response = wp_remote_post( $endpoint, array(
-            'method'    => 'POST',
-            'body'      => http_build_query( $data ),
+        return $this->make_request( $endpoint, $data );
+    }
+
+    /**
+     * Récupérer les statuts des colis depuis l'API Navex.
+     *
+     * @return array|WP_Error La réponse de l'API ou une erreur.
+     */
+    public function get_parcels_status() {
+        if ( empty( $this->token_get ) ) {
+            return new WP_Error( 'api_token_missing', __( 'Le token de récupération Navex n\'est pas configuré.', 'abcdo-wc-navex' ) );
+        }
+
+        // L'endpoint exact doit être confirmé par la documentation de Navex.
+        // C'est une supposition basée sur les conventions.
+        $endpoint = self::$api_url . $this->token_get . '/v1/get.php';
+
+        // La méthode est probablement GET, donc le corps est vide.
+        return $this->make_request( $endpoint, array(), 'GET' );
+    }
+
+    /**
+     * Fonction utilitaire pour effectuer les requêtes à l'API.
+     *
+     * @param string $endpoint L'URL complète de l'endpoint.
+     * @param array  $data Les données à envoyer.
+     * @param string $method La méthode HTTP (POST, GET).
+     * @return array|WP_Error La réponse de l'API ou une erreur.
+     */
+    private function make_request( $endpoint, $data = array(), $method = 'POST' ) {
+        $args = array(
+            'method'    => $method,
             'headers'   => array(
                 'Content-Type' => 'application/x-www-form-urlencoded',
             ),
             'timeout'   => 45,
-        ) );
+        );
+
+        if ( 'POST' === $method && ! empty( $data ) ) {
+            $args['body'] = http_build_query( $data );
+        }
+
+        $response = wp_remote_request( $endpoint, $args );
 
         if ( is_wp_error( $response ) ) {
             return $response;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ABCDO
 Tags: woocommerce, shipping, delivery, navex, integration
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.14
+Stable tag: 1.0.15
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -23,9 +23,15 @@ Ce plugin connecte votre boutique WooCommerce au service de livraison tunisien N
 1.  Téléchargez le fichier `.zip` du plugin.
 2.  Allez dans `WordPress Admin > Extensions > Ajouter` et cliquez sur `Téléverser une extension`.
 3.  Choisissez le fichier `.zip` et activez le plugin.
-4.  Allez dans `WooCommerce > Réglages > Intégration > ABCDO Navex` et entrez votre clé d'API Navex.
+4.  Allez dans `Navex Delivery > Settings` et entrez vos clés d'API Navex (ajout, récupération, suppression).
 
 == Changelog ==
+
+= 1.0.15 =
+*   Fonctionnalité : Ajout d'un tableau de bord de suivi des colis (`Navex Delivery`).
+*   Fonctionnalité : Refonte de la page de réglages avec des champs dédiés pour les tokens d'ajout, de récupération et de suppression.
+*   Amélioration : Ajout d'une icône de menu personnalisée pour une meilleure identification.
+*   Amélioration : La logique AJAX est maintenant gérée par un script dédié et sécurisée par un nonce unifié.
 
 = 1.0.14 =
 *   Correction : Résolution d'une erreur fatale dans le système de mise à jour.


### PR DESCRIPTION
This commit introduces the ability for administrators to manually send an order to the Navex API, providing more control over the shipping process.

Key changes:
- Add a "Navex Shipment" meta box to the WooCommerce order edit page. This box displays the tracking number and includes a button to manually trigger the API call.
- Add a "Send to Navex" quick action button to the main order list screen.
- Implement an AJAX endpoint and corresponding JavaScript to handle the manual submission, providing real-time feedback to the user.
- Refactor the API client to be more robust, accept a `WC_Order` object, and store the API response and tracking number in order meta fields.
- Add internationalization support (i18n) to prepare the plugin for translation.
- Update plugin version to 1.0.15 and refresh documentation.