### PR TITLE
feat: Encrypt API tokens and add parcel details modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.17] - 2025-07-19
+
+### Ajouté
+- **Chiffrement des Tokens :** Les tokens d'API sont maintenant chiffrés en base de données en utilisant les sels de sécurité de WordPress pour une sécurité accrue.
+- **Fonctionnalité "Détails du Colis" :** Le bouton "Détails" dans le tableau de bord ouvre désormais une fenêtre modale affichant les informations complètes du colis récupérées via une nouvelle requête API.
+
+### Corrigé
+- **Synchronisation des Colis :** La liste des colis affichée dans le tableau de bord est maintenant directement liée aux commandes WooCommerce existantes. Les colis dont les commandes ont été supprimées n'apparaissent plus.
+- **Chargement des Traductions :** Le "textdomain" est maintenant chargé sur le hook `init` pour se conformer aux standards WordPress et éliminer les notices PHP.
+
+### Modifié
+- **Logique de l'API :** La classe API a été mise à jour pour gérer le déchiffrement des tokens et inclure une nouvelle méthode pour récupérer les détails d'un colis spécifique.
+- **Logique d'Administration :** La classe Admin gère maintenant la sauvegarde des tokens chiffrés, la nouvelle source de données pour la liste des colis, et l'endpoint AJAX pour la modale de détails.
+
 ## [1.0.16] - 2025-07-19
 
 ### Corrigé

--- a/abcdo-wc-navex.php
+++ b/abcdo-wc-navex.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ABCDO Navex Integration for WooCommerce
  * Plugin URI:        https://github.com/ABCDO-TN/abcdo-wc-navex
  * Description:       Intègre l'API de livraison Navex avec WooCommerce pour automatiser la création de colis.
- * Version:           1.0.16
+ * Version:           1.0.17
  * Author:            ABCDO
  * Author URI:        https://abcdo.tn
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ add_action( 'before_woocommerce_init', function() {
 } );
 
 // Définir les constantes du plugin
-define( 'ABCDO_WC_NAVEX_VERSION', '1.0.16' );
+define( 'ABCDO_WC_NAVEX_VERSION', '1.0.17' );
 define( 'ABCDO_WC_NAVEX_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_URL', plugin_dir_url( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );
@@ -41,6 +41,7 @@ define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );
  */
 function abcd_wc_navex_init() {
     // Charger les fichiers nécessaires
+    include_once( ABCDO_WC_NAVEX_PATH . 'includes/class-abcd-wc-navex-crypto.php' );
     include_once( ABCDO_WC_NAVEX_PATH . 'includes/class-abcd-wc-navex-api.php' );
     include_once( ABCDO_WC_NAVEX_PATH . 'includes/class-abcd-wc-navex-admin.php' );
     include_once( ABCDO_WC_NAVEX_PATH . 'includes/class-abcd-wc-navex-updater.php' );
@@ -54,3 +55,11 @@ function abcd_wc_navex_init() {
     }
 }
 add_action( 'plugins_loaded', 'abcd_wc_navex_init' );
+
+/**
+ * Charge les traductions du plugin.
+ */
+function abcd_wc_navex_load_textdomain() {
+    load_plugin_textdomain( 'abcdo-wc-navex', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'abcd_wc_navex_load_textdomain' );

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,51 @@
+/* Styles pour la modale de détails Navex */
+
+#navex-details-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+}
+
+#navex-details-modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    z-index: 1001;
+    width: 90%;
+    max-width: 500px;
+}
+
+#navex-details-modal-content h2 {
+    margin-top: 0;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: 15px;
+    margin-bottom: 15px;
+}
+
+#navex-modal-body ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+#navex-modal-body li {
+    padding: 5px 0;
+    border-bottom: 1px solid #eee;
+}
+
+#navex-modal-body li:last-child {
+    border-bottom: none;
+}
+
+#navex-modal-close {
+    margin-top: 20px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -8,12 +8,44 @@
             loadParcels();
         }
 
+        // Gestion de la modale de détails
+        var modal = $('#navex-details-modal');
+        var modalBody = $('#navex-modal-body');
+
+        // Ouvrir la modale
+        $(document).on('click', '.navex-details-btn', function(e) {
+            e.preventDefault();
+            var trackingId = $(this).data('tracking-id');
+            
+            modal.show();
+            modalBody.html('<span class="spinner is-active"></span>');
+
+            var data = {
+                action: 'abcd_wc_navex_get_parcel_details',
+                nonce: abcd_wc_navex_ajax.nonce,
+                tracking_id: trackingId
+            };
+
+            $.post(abcd_wc_navex_ajax.ajax_url, data, function(response) {
+                if (response.success) {
+                    modalBody.html(response.data.html);
+                } else {
+                    modalBody.html('<p>Erreur: ' + response.data.message + '</p>');
+                }
+            });
+        });
+
+        // Fermer la modale
+        $('#navex-modal-close, #navex-modal-backdrop').on('click', function() {
+            modal.hide();
+        });
+
+
         // Logique pour le bouton d'envoi sur la page de commande
         $('#abcd-wc-navex-send-btn').on('click', function() {
             var button = $(this);
             var spinner = button.next('.spinner');
             var orderId = button.data('order-id');
-            var nonce = $('#abcd_wc_navex_nonce').val();
 
             button.prop('disabled', true);
             spinner.css('visibility', 'visible');
@@ -21,16 +53,15 @@
             var data = {
                 action: 'abcd_wc_navex_send_parcel',
                 order_id: orderId,
-                nonce: nonce
+                nonce: abcd_wc_navex_ajax.nonce
             };
 
-            $.post(ajaxurl, data, function(response) {
+            $.post(abcd_wc_navex_ajax.ajax_url, data, function(response) {
                 button.prop('disabled', false);
                 spinner.css('visibility', 'hidden');
 
                 if (response.success) {
                     alert(response.data.message);
-                    // Mettre à jour l'affichage du statut sans recharger la page
                     button.closest('div').html('<p><strong>Navex Status:</strong> Envoyé</p>');
                 } else {
                     alert('Erreur: ' + response.data.message);
@@ -50,7 +81,7 @@
             };
 
             $.post(abcd_wc_navex_ajax.ajax_url, data, function(response) {
-                tableBody.empty(); // Vider le message de chargement
+                tableBody.empty();
 
                 if (response.success) {
                     if (response.data.length > 0) {

--- a/includes/class-abcd-wc-navex-crypto.php
+++ b/includes/class-abcd-wc-navex-crypto.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Fichier pour la gestion du chiffrement.
+ *
+ * @package Abcdo_Wc_Navex
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Classe pour gérer le chiffrement et le déchiffrement des données.
+ */
+class ABCD_WC_Navex_Crypto {
+
+    /**
+     * L'algorithme de chiffrement.
+     *
+     * @var string
+     */
+    private const CIPHER_ALGO = 'aes-256-cbc';
+
+    /**
+     * Chiffrer une chaîne de caractères.
+     *
+     * @param string $data La chaîne à chiffrer.
+     * @return string|false La chaîne chiffrée ou false en cas d'erreur.
+     */
+    public static function encrypt( $data ) {
+        $key = self::get_encryption_key();
+        $iv_length = openssl_cipher_iv_length( self::CIPHER_ALGO );
+        $iv = openssl_random_pseudo_bytes( $iv_length );
+
+        $encrypted = openssl_encrypt( $data, self::CIPHER_ALGO, $key, 0, $iv );
+
+        if ( false === $encrypted ) {
+            return false;
+        }
+
+        return base64_encode( $iv . $encrypted );
+    }
+
+    /**
+     * Déchiffrer une chaîne de caractères.
+     *
+     * @param string $data La chaîne chiffrée.
+     * @return string|false La chaîne déchiffrée ou false en cas d'erreur.
+     */
+    public static function decrypt( $data ) {
+        $key = self::get_encryption_key();
+        $data = base64_decode( $data, true );
+
+        if ( false === $data ) {
+            return false;
+        }
+
+        $iv_length = openssl_cipher_iv_length( self::CIPHER_ALGO );
+        $iv = substr( $data, 0, $iv_length );
+        $encrypted_data = substr( $data, $iv_length );
+
+        return openssl_decrypt( $encrypted_data, self::CIPHER_ALGO, $key, 0, $iv );
+    }
+
+    /**
+     * Générer une clé de chiffrement à partir des sels WordPress.
+     *
+     * @return string La clé de chiffrement.
+     */
+    private static function get_encryption_key() {
+        $key = '';
+        if ( defined( 'AUTH_KEY' ) ) {
+            $key .= AUTH_KEY;
+        }
+        if ( defined( 'SECURE_AUTH_KEY' ) ) {
+            $key .= SECURE_AUTH_KEY;
+        }
+        if ( defined( 'LOGGED_IN_KEY' ) ) {
+            $key .= LOGGED_IN_KEY;
+        }
+
+        // S'assurer que la clé a la bonne longueur pour AES-256
+        return substr( hash( 'sha256', $key ), 0, 32 );
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ABCDO
 Tags: woocommerce, shipping, delivery, navex, integration
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.16
+Stable tag: 1.0.17
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -26,6 +26,12 @@ Ce plugin connecte votre boutique WooCommerce au service de livraison tunisien N
 4.  Allez dans `Navex Delivery > Settings` et entrez vos clés d'API Navex (ajout, récupération, suppression).
 
 == Changelog ==
+
+= 1.0.17 =
+*   Fonctionnalité : Le bouton "Détails" est maintenant fonctionnel et ouvre une fenêtre modale avec les informations du colis.
+*   Fonctionnalité : Ajout du chiffrement pour les tokens d'API stockés en base de données.
+*   Correction : La liste des colis est maintenant synchronisée avec les commandes WooCommerce, les colis liés à des commandes supprimées n'apparaissent plus.
+*   Correction : Le chargement des fichiers de traduction se fait maintenant sur le bon hook pour éviter les notices PHP.
 
 = 1.0.16 =
 *   Correction : Résolution d'une erreur fatale dans le système de mise à jour qui provoquait la disparition des plugins et des notifications de mise à jour.


### PR DESCRIPTION
This commit introduces two major enhancements and several fixes.

- **Security:** API tokens are now encrypted in the database using a new `Crypto` class that leverages WordPress's built-in salts. This significantly improves the security of stored credentials.

- **Parcel Details Modal:** A "Details" button has been added to the admin parcel list. Clicking it opens a modal and fetches complete, real-time parcel details from the Navex API, providing users with more information directly in the dashboard.

- **Fix:** The parcel list is now synchronized with existing WooCommerce orders. Parcels for which the corresponding order has been deleted are no longer displayed.

- **Fix:** The plugin textdomain is now loaded on the `init` hook to follow WordPress best practices and resolve potential PHP notices.