### PR TITLE
Fix: Handle raw text API response and stabilize updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.18] - 2025-07-19
+
+### Corrigé
+- **Gestion des Réponses API :** L'appel pour les détails d'un colis traite maintenant correctement les réponses textuelles brutes, résolvant l'erreur "Réponse JSON invalide".
+- **Stabilité des Mises à Jour :** Suppression du nettoyage agressif et inutile du cache des mises à jour (`update_plugins` transient), ce qui stabilise le système de mises à jour de WordPress et résout les incohérences d'affichage.
+
 ## [1.0.17] - 2025-07-19
 
 ### Ajouté

--- a/abcdo-wc-navex.php
+++ b/abcdo-wc-navex.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ABCDO Navex Integration for WooCommerce
  * Plugin URI:        https://github.com/ABCDO-TN/abcdo-wc-navex
  * Description:       Intègre l'API de livraison Navex avec WooCommerce pour automatiser la création de colis.
- * Version:           1.0.17
+ * Version:           1.0.18
  * Author:            ABCDO
  * Author URI:        https://abcdo.tn
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ add_action( 'before_woocommerce_init', function() {
 } );
 
 // Définir les constantes du plugin
-define( 'ABCDO_WC_NAVEX_VERSION', '1.0.17' );
+define( 'ABCDO_WC_NAVEX_VERSION', '1.0.18' );
 define( 'ABCDO_WC_NAVEX_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_URL', plugin_dir_url( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-abcd-wc-navex-admin.php
+++ b/includes/class-abcd-wc-navex-admin.php
@@ -364,12 +364,9 @@ class ABCD_WC_Navex_Admin {
             wp_send_json_error( array( 'message' => $response->get_error_message() ) );
         }
 
-        // Formatter la réponse pour l'affichage
-        $html = '<ul>';
-        foreach ( $response as $key => $value ) {
-            $html .= sprintf( '<li><strong>%s:</strong> %s</li>', esc_html( ucwords( str_replace( '_', ' ', $key ) ) ), esc_html( $value ) );
-        }
-        $html .= '</ul>';
+        // La réponse est une chaîne de caractères, pas un tableau.
+        // On l'enveloppe simplement dans un paragraphe.
+        $html = '<p>' . esc_html( $response ) . '</p>';
 
         wp_send_json_success( array( 'html' => $html ) );
     }

--- a/includes/class-abcd-wc-navex-api.php
+++ b/includes/class-abcd-wc-navex-api.php
@@ -114,8 +114,13 @@ class ABCD_WC_Navex_API {
         $body = wp_remote_retrieve_body( $response );
         $decoded_body = json_decode( $body, true );
 
+        // Pour la méthode get_parcel_details, la réponse n'est pas du JSON.
+        // On vérifie si la requête vient de là pour retourner le corps brut.
+        if ( strpos( $endpoint, '/get.php' ) !== false ) {
+            return $body;
+        }
+
         if ( json_last_error() !== JSON_ERROR_NONE ) {
-            // Pour le débogage, on peut retourner le corps brut en cas d'erreur JSON
             return new WP_Error( 'invalid_json', __( 'Réponse JSON invalide de l\'API Navex.', 'abcdo-wc-navex' ), array( 'body' => $body ) );
         }
 

--- a/includes/class-abcd-wc-navex-updater.php
+++ b/includes/class-abcd-wc-navex-updater.php
@@ -45,11 +45,6 @@ class ABCD_WC_Navex_Updater {
         add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
         add_filter( 'plugins_api', array( $this, 'plugin_popup' ), 10, 3 );
         add_filter( 'upgrader_source_selection', array( $this, 'upgrader_source_selection' ), 10, 4 );
-        add_action( 'load-update-core.php', array( $this, 'clear_update_transient' ) );
-    }
-
-    public function clear_update_transient() {
-        set_site_transient( 'update_plugins', null );
     }
 
     private function get_repository_info() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ABCDO
 Tags: woocommerce, shipping, delivery, navex, integration
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.17
+Stable tag: 1.0.18
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -26,6 +26,10 @@ Ce plugin connecte votre boutique WooCommerce au service de livraison tunisien N
 4.  Allez dans `Navex Delivery > Settings` et entrez vos clés d'API Navex (ajout, récupération, suppression).
 
 == Changelog ==
+
+= 1.0.18 =
+*   Correction : L'appel API pour les détails d'un colis gère maintenant correctement les réponses non-JSON, corrigeant l'erreur "Réponse JSON invalide".
+*   Correction : Suppression du nettoyage agressif du cache des mises à jour, ce qui résout les incohérences dans la page des mises à jour de WordPress.
 
 = 1.0.17 =
 *   Fonctionnalité : Le bouton "Détails" est maintenant fonctionnel et ouvre une fenêtre modale avec les informations du colis.


### PR DESCRIPTION
This commit addresses two issues:

1.  **API Response Handling:** The parcel details endpoint (`/get.php`) returns a raw text string, not JSON. The code now correctly handles this plain text response, resolving the "Invalid JSON response" error that occurred when fetching parcel details.

2.  **Update Stability:** Removed the aggressive and unnecessary clearing of the `update_plugins` transient. This was causing instability in the WordPress update system and leading to inconsistent update notifications. The updater mechanism is now more stable and compliant with WordPress standards.