### PR TITLE
Fix: Ensure HPOS compatibility for order queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Toutes les modifications notables apportées à ce projet seront documentées da
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et ce projet adhère à [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2025-07-21
+
+### Corrigé
+- **Compatibilité HPOS :** La requête `wc_get_orders` dans la fonction `ajax_get_parcels` a été réécrite pour être entièrement compatible avec le stockage de commandes haute performance (HPOS). Cela résout l'erreur fatale `WC_Order_Data_Store_CPT::query was called incorrectly` et corrige la désynchronisation des colis.
+
 ## [1.0.18] - 2025-07-19
 
 ### Corrigé

--- a/abcdo-wc-navex.php
+++ b/abcdo-wc-navex.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ABCDO Navex Integration for WooCommerce
  * Plugin URI:        https://github.com/ABCDO-TN/abcdo-wc-navex
  * Description:       Intègre l'API de livraison Navex avec WooCommerce pour automatiser la création de colis.
- * Version:           1.0.18
+ * Version:           1.0.19
  * Author:            ABCDO
  * Author URI:        https://abcdo.tn
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ add_action( 'before_woocommerce_init', function() {
 } );
 
 // Définir les constantes du plugin
-define( 'ABCDO_WC_NAVEX_VERSION', '1.0.18' );
+define( 'ABCDO_WC_NAVEX_VERSION', '1.0.19' );
 define( 'ABCDO_WC_NAVEX_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_URL', plugin_dir_url( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-abcd-wc-navex-admin.php
+++ b/includes/class-abcd-wc-navex-admin.php
@@ -314,15 +314,9 @@ class ABCD_WC_Navex_Admin {
         }
 
         $args = array(
-            'post_type'   => 'shop_order',
-            'post_status' => 'any',
-            'posts_per_page' => -1,
-            'meta_query'  => array(
-                array(
-                    'key'     => '_navex_tracking_id',
-                    'compare' => 'EXISTS',
-                ),
-            ),
+            'limit' => -1, // Récupérer toutes les commandes
+            'status' => 'any',
+            '_navex_tracking_id' => 'EXISTS',
         );
         $orders = wc_get_orders( $args );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ABCDO
 Tags: woocommerce, shipping, delivery, navex, integration
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.18
+Stable tag: 1.0.19
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -26,6 +26,9 @@ Ce plugin connecte votre boutique WooCommerce au service de livraison tunisien N
 4.  Allez dans `Navex Delivery > Settings` et entrez vos clés d'API Navex (ajout, récupération, suppression).
 
 == Changelog ==
+
+= 1.0.19 =
+*   Correction : La requête pour récupérer les commandes est maintenant compatible avec le stockage de commandes haute performance (HPOS), résolvant une erreur fatale et la désynchronisation des colis.
 
 = 1.0.18 =
 *   Correction : L'appel API pour les détails d'un colis gère maintenant correctement les réponses non-JSON, corrigeant l'erreur "Réponse JSON invalide".


### PR DESCRIPTION
Update the arguments for the `wc_get_orders` function to the modern format compatible with WooCommerce High-Performance Order Storage (HPOS).

The previous `WP_Query`-style arguments caused a fatal error (`WC_Order_Data_Store_CPT::query was called incorrectly`) when HPOS was enabled. This change resolves the error and fixes a related bug causing parcel desynchronization.

The plugin version is also bumped to 1.0.19.