### PR TITLE
chore(release): Simplify and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,40 +17,18 @@ jobs:
       id: get_version
       run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
-    - name: Create plugin ZIP
+    - name: Build the plugin zip
       run: |
-        PLUGIN_SLUG="abcdo-wc-navex"
-        zip -r "${PLUGIN_SLUG}.zip" . -x ".git/*" ".github/*" "README.md"
-
-    - name: Get Release Body
-      id: get_release_body
-      run: |
-        CHANGELOG_BODY=$(awk '/## \['"$VERSION"'\]/{flag=1; next} /## \[/{flag=0} flag' CHANGELOG.md)
-        CHANGELOG_BODY="${CHANGELOG_BODY//'%'/'%25'}"
-        CHANGELOG_BODY="${CHANGELOG_BODY//$'\n'/'%0A'}"
-        CHANGELOG_BODY="${CHANGELOG_BODY//$'\r'/'%0D'}"
-        echo "BODY<<EOF" >> $GITHUB_ENV
-        echo "$CHANGELOG_BODY" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
-
-    - name: Create GitHub Release
+        mkdir abcdo-wc-navex
+        cp -r ./* abcdo-wc-navex/
+        rm -rf abcdo-wc-navex/.git
+        rm -rf abcdo-wc-navex/.github
+        zip -r abcdo-wc-navex.zip abcdo-wc-navex
+        
+    - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: "Release ${{ env.VERSION }}"
-        body: ${{ env.BODY }}
-        draft: false
-        prerelease: false
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./abcdo-wc-navex.zip
-        asset_name: abcdo-wc-navex.zip
-        asset_content_type: application/zip
+        artifacts: "abcdo-wc-navex.zip"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        generateReleaseNotes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2025-07-21
+
+### Fixed
+- **GitHub Actions Workflow:** Corrected and simplified the release workflow to ensure the plugin `.zip` archive is built correctly and that release notes are generated automatically.
+
+### Changed
+- **Release Process:** The release process is now more robust, using a dedicated action that handles artifact uploads and release note generation.
+
 ## [1.0.21] - 2025-07-21
 
 ### Added

--- a/abcdo-wc-navex.php
+++ b/abcdo-wc-navex.php
@@ -3,7 +3,7 @@
  * Plugin Name:       ABCDO Navex Integration for WooCommerce
  * Plugin URI:        https://github.com/ABCDO-TN/abcdo-wc-navex
  * Description:       Integrates Navex delivery API with WooCommerce to automate parcel creation.
- * Version:           1.0.21
+ * Version:           1.0.22
  * Author:            ABCDO
  * Author URI:        https://abcdo.tn
  * License:           GPL-2.0+
@@ -30,7 +30,7 @@ add_action( 'before_woocommerce_init', function() {
 } );
 
 // Define plugin constants
-define( 'ABCDO_WC_NAVEX_VERSION', '1.0.21' );
+define( 'ABCDO_WC_NAVEX_VERSION', '1.0.22' );
 define( 'ABCDO_WC_NAVEX_PATH', plugin_dir_path( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_URL', plugin_dir_url( __FILE__ ) );
 define( 'ABCDO_WC_NAVEX_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: ABCDO
 Tags: woocommerce, shipping, delivery, navex, integration
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.21
+Stable tag: 1.0.22
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -26,6 +26,10 @@ This plugin connects your WooCommerce store to the Tunisian delivery service Nav
 4.  Go to `Navex Delivery > Settings` and enter your Navex API keys (add, get, delete).
 
 == Changelog ==
+
+= 1.0.22 =
+*   Fix: Corrected and simplified the GitHub Actions workflow to ensure the plugin `.zip` is created correctly.
+*   Enhancement: The release process is now more robust and automatically generates release notes.
 
 = 1.0.21 =
 *   Feature: Implemented a GitHub Actions workflow to automate the creation of release packages.


### PR DESCRIPTION
This commit refactors the GitHub Actions release workflow to improve its reliability and simplicity.

The previous multi-step process for creating the zip and parsing the changelog has been replaced with the `ncipollo/release-action`. This new action simplifies the workflow by automatically generating release notes.

Additionally, the zip creation step is corrected to package the plugin files inside a proper root directory, which is standard for WordPress plugin distribution. The plugin version is bumped to 1.0.22 to reflect these changes.